### PR TITLE
Fix Markdown Rendering for Streaming Messages

### DIFF
--- a/deepseek/deepseek.go
+++ b/deepseek/deepseek.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"log"
+	"strings"
+	"time"
+
 	"github.com/cohesion-org/deepseek-go"
 	"github.com/cohesion-org/deepseek-go/constants"
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
@@ -12,14 +17,10 @@ import (
 	"github.com/yincongcyincong/telegram-deepseek-bot/metrics"
 	"github.com/yincongcyincong/telegram-deepseek-bot/param"
 	"github.com/yincongcyincong/telegram-deepseek-bot/utils"
-	"io"
-	"log"
-	"strings"
-	"time"
 )
 
 const (
-	OneMsgLen       = 900
+	OneMsgLen       = 4000
 	FirstSendLen    = 30
 	NonFirstSendLen = 300
 )

--- a/robot/robot.go
+++ b/robot/robot.go
@@ -82,7 +82,6 @@ func requestDeepseekAndResp(update tgbotapi.Update, bot *tgbotapi.BotAPI, conten
 // handleUpdate handle robot msg sending
 func handleUpdate(messageChan chan *param.MsgInfo, update tgbotapi.Update, bot *tgbotapi.BotAPI, content string) {
 	var msg *param.MsgInfo
-	var lastMsg *param.MsgInfo // Last message to render as Markdown
 
 	chatId, msgId, username := utils.GetChatIdAndMsgIdAndUserID(update)
 	for msg = range messageChan {
@@ -128,17 +127,16 @@ func handleUpdate(messageChan chan *param.MsgInfo, update tgbotapi.Update, bot *
 				}
 			}
 		}
-		lastMsg = msg // save last message
 	}
 
 	// Render last full message with markdown
-	if lastMsg != nil && lastMsg.MsgId != 0 {
+	if msg != nil && msg.MsgId != 0 {
 		finalUpdateMsg := tgbotapi.EditMessageTextConfig{
 			BaseEdit: tgbotapi.BaseEdit{
 				ChatID:    chatId,
-				MessageID: lastMsg.MsgId,
+				MessageID: msg.MsgId,
 			},
-			Text:      lastMsg.FullContent,   // FullContent
+			Text:      msg.FullContent,       // FullContent
 			ParseMode: tgbotapi.ModeMarkdown, // Parse with Markdown
 		}
 		_, err := bot.Send(finalUpdateMsg)


### PR DESCRIPTION
## Problem

1. In stream messages, incomplete messages often break Markdown rendering rules (e.g. an incomplete code block), and TG Bot API refuses send/edit requests of such messages, causing incomplete messages.
2. Original message length is 900, therefore a single response is ususlly cut into many shorter messages.

## Solution

1. For Markdown rendering problem, Modified the `handleUpdate` function in `robot/robot.go` to postpone Markdown rendering until the entire message stream is processed.

    - During the incremental message updates within the streaming loop, `ParseMode` is disabled for both initial message sending and subsequent edits.
    - After the streaming loop completes and the full message content is accumulated, a final `editMessageText` request is sent. This final request includes `ParseMode: tgbotapi.ModeMarkdown`.

2. For message length, prolonged the length from 900 to 4000.
