### PR TITLE
fix markdown render problem

### DIFF
--- a/robot/robot.go
+++ b/robot/robot.go
@@ -82,7 +82,6 @@ func requestDeepseekAndResp(update tgbotapi.Update, bot *tgbotapi.BotAPI, conten
 // handleUpdate handle robot msg sending
 func handleUpdate(messageChan chan *param.MsgInfo, update tgbotapi.Update, bot *tgbotapi.BotAPI, content string) {
 	var msg *param.MsgInfo
-	var lastMsg *param.MsgInfo // Last message to render as Markdown
 
 	chatId, msgId, username := utils.GetChatIdAndMsgIdAndUserID(update)
 	for msg = range messageChan {
@@ -128,17 +127,16 @@ func handleUpdate(messageChan chan *param.MsgInfo, update tgbotapi.Update, bot *
 				}
 			}
 		}
-		lastMsg = msg // save last message
 	}
 
 	// Render last full message with markdown
-	if lastMsg != nil && lastMsg.MsgId != 0 {
+	if msg != nil && msg.MsgId != 0 {
 		finalUpdateMsg := tgbotapi.EditMessageTextConfig{
 			BaseEdit: tgbotapi.BaseEdit{
 				ChatID:    chatId,
-				MessageID: lastMsg.MsgId,
+				MessageID: msg.MsgId,
 			},
-			Text:      lastMsg.FullContent,   // FullContent
+			Text:      msg.FullContent,       // FullContent
 			ParseMode: tgbotapi.ModeMarkdown, // Parse with Markdown
 		}
 		_, err := bot.Send(finalUpdateMsg)


### PR DESCRIPTION
During stream output, incomplete markdown components (e.g. an incomplete code block) break markdown rendering rules, and Telegram API refuses send/edit requests with such inputs, making messages updated incorrectly.

To address the issue, `ParseMode` is disabled in stream output phase, letting the message parsed as plain texts (so to avoid request refusals); as the stream completes, a final edit request is sent with `ParseMode` enabled, allowing message to be rendered as Markdown.