### PR TITLE
lenghtened single message length

### DIFF
--- a/deepseek/deepseek.go
+++ b/deepseek/deepseek.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	OneMsgLen       = 4096
+	OneMsgLen       = 3896
 	FirstSendLen    = 30
 	NonFirstSendLen = 300
 )

--- a/deepseek/deepseek.go
+++ b/deepseek/deepseek.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"log"
+	"strings"
+	"time"
+
 	"github.com/cohesion-org/deepseek-go"
 	"github.com/cohesion-org/deepseek-go/constants"
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
@@ -12,14 +17,10 @@ import (
 	"github.com/yincongcyincong/telegram-deepseek-bot/metrics"
 	"github.com/yincongcyincong/telegram-deepseek-bot/param"
 	"github.com/yincongcyincong/telegram-deepseek-bot/utils"
-	"io"
-	"log"
-	"strings"
-	"time"
 )
 
 const (
-	OneMsgLen       = 900
+	OneMsgLen       = 4000
 	FirstSendLen    = 30
 	NonFirstSendLen = 300
 )

--- a/deepseek/deepseek.go
+++ b/deepseek/deepseek.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	OneMsgLen       = 4000
+	OneMsgLen       = 4096
 	FirstSendLen    = 30
 	NonFirstSendLen = 300
 )
@@ -104,7 +104,7 @@ func callDeepSeekAPI(prompt string, update tgbotapi.Update, messageChan chan *pa
 		}
 		for _, choice := range response.Choices {
 			// exceed max telegram one message length
-			if len(msgInfoContent.Content) > OneMsgLen {
+			if utils.Utf16len(msgInfoContent.Content) > OneMsgLen {
 				messageChan <- msgInfoContent
 				msgInfoContent = &param.MsgInfo{
 					SendLen:     FirstSendLen,

--- a/deepseek/huoshan.go
+++ b/deepseek/huoshan.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/yincongcyincong/telegram-deepseek-bot/metrics"
-
 	"io"
 	"log"
 	"strings"
@@ -19,6 +17,7 @@ import (
 	"github.com/volcengine/volcengine-go-sdk/service/arkruntime/model"
 	"github.com/yincongcyincong/telegram-deepseek-bot/conf"
 	"github.com/yincongcyincong/telegram-deepseek-bot/db"
+	"github.com/yincongcyincong/telegram-deepseek-bot/metrics"
 	"github.com/yincongcyincong/telegram-deepseek-bot/param"
 	"github.com/yincongcyincong/telegram-deepseek-bot/utils"
 )
@@ -117,7 +116,7 @@ func getContentFromHS(prompt string, update tgbotapi.Update, messageChan chan *p
 		}
 		for _, choice := range response.Choices {
 			// exceed max telegram one message length
-			if len(msgInfoContent.Content) > OneMsgLen {
+			if utils.Utf16len(msgInfoContent.Content) > OneMsgLen {
 				messageChan <- msgInfoContent
 				msgInfoContent = &param.MsgInfo{
 					SendLen:     FirstSendLen,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,6 +1,10 @@
 package utils
 
-import tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+import (
+	"unicode/utf16"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
 
 func GetChatIdAndMsgIdAndUserID(update tgbotapi.Update) (int64, int, int64) {
 	chatId := int64(0)
@@ -22,4 +26,10 @@ func GetChatIdAndMsgIdAndUserID(update tgbotapi.Update) (int64, int, int64) {
 
 func CheckMsgIsCallback(update tgbotapi.Update) bool {
 	return update.CallbackQuery != nil
+}
+
+// Utf16len calculates the length of a string in UTF-16 code units.
+func Utf16len(s string) int {
+	utf16Str := utf16.Encode([]rune(s))
+	return len(utf16Str)
 }


### PR DESCRIPTION
As mentioned in [an API issue](https://github.com/go-telegram-bot-api/telegram-bot-api/issues/231), Telegram API supports at most 4096 UTF-16 characters in a single message, much longer than original 900 UTF-8 bytes.

This PR calculates UTF-16 length of encoded texts to be sent, and only split messages when the length exceeds the 4096 limit.